### PR TITLE
Fix and organize imports

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -1,3 +1,8 @@
+from typing import Optional
+import logging
+import json
+
+
 class JobGraphNode:
     def __init__(self, job_obj, node_id, name: Optional[str] = None):
         self.job = job_obj
@@ -16,8 +21,6 @@ class JobGraphNode:
     @property
     def parents(self):
         return self.sources
-
-import json
 
 class JobGraph:
     def __init__(self, trace=False):

--- a/mapping_job.py
+++ b/mapping_job.py
@@ -1,10 +1,16 @@
 import random
 import queue
-from collections import defaultdict
+import threading
+import time
+import logging
+from collections import defaultdict, deque
 from typing import Callable, List, Optional, Tuple, Any, Iterator, Dict
+
 import pandas as pd
-from pigeon_core.payload import PigeonTapePayload
-from pigeon_core.color import ColorMap
+
+from graph import JobGraph, JobGraphNode
+from payload import PigeonTapePayload
+from pigeon import PigeonCrusher, append_hue_to_tape
 from pigeon_core.logging import get_logger, TRACE
 from pigeon_crusher_helper import PigeonCrushKernelHelper
 

--- a/primitives.py
+++ b/primitives.py
@@ -1,4 +1,12 @@
 
+from collections import deque, defaultdict
+import queue
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+
+from payload import PigeonTapePayload
+from mapping_job import MappingJob
+
+
 class PigeonCrushedBase:
     """
     Mixin/base for crushed primitives.
@@ -185,9 +193,6 @@ class CrushList(PigeonCrushedBase, list):
 
     def __repr__(self):
         return f"CrushList({list(self)})"
-from collections import deque, defaultdict
-import numpy as np
-from pigeon_crushing import MappingJob  # Use your real import
 
 class CrushDict(PigeonCrushedBase, dict):
     """

--- a/ring_lab.py
+++ b/ring_lab.py
@@ -1,3 +1,14 @@
+import queue
+from collections import deque
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from mapping_job import MappingJob, JobJoiner, JobManager
+from payload import PigeonTapePayload
+
+
 class RingNode(nn.Module):
     def __init__(self, param_dim=1):
         super().__init__()

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,3 +1,20 @@
+import numpy as np
+import pygame
+from collections import deque, defaultdict
+from typing import List
+
+from color import normalize_weights, ColorMap
+from ring_lab import PigeonRingLab
+from OpenGL.GL import (
+    glGenTextures, glBindTexture, glTexParameteri, glTexImage2D, glTexSubImage2D,
+    glBegin, glEnd, glTexCoord2f, glVertex2f, glClear, glClearColor, glViewport,
+    glLoadIdentity, glOrtho, glMatrixMode, glEnable,
+    GL_TEXTURE_2D, GL_RGBA, GL_UNSIGNED_BYTE, GL_LINEAR, GL_CLAMP_TO_EDGE,
+    GL_QUADS, GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_TEXTURE_MIN_FILTER,
+    GL_TEXTURE_MAG_FILTER, GL_TEXTURE_WRAP_S, GL_TEXTURE_WRAP_T, GL_PROJECTION,
+    GL_MODELVIEW, GL_NEAREST,
+)
+
 
 class PigeonVisualizer:
     def __init__(


### PR DESCRIPTION
## Summary
- add missing imports for JobGraph and logging
- organize mapping job imports and drop unused color map
- centralize primitives imports and remove bottom-of-file duplicates
- wire up ring lab and visualizer with required modules

## Testing
- `python -m py_compile color.py graph.py logging.py mapping_job.py payload.py primitives.py ring_lab.py visualizer.py pigeon.py`


------
https://chatgpt.com/codex/tasks/task_e_688e70af78b4832a91e3d4eb64e43ac0